### PR TITLE
Show same domain as (direct) in referrers

### DIFF
--- a/src/components/domains/referrer_event_component.cr
+++ b/src/components/domains/referrer_event_component.cr
@@ -1,13 +1,18 @@
 class ReferrerEventComponent < BaseComponent
   needs domain : String?
+  needs real_domain : String
   needs percentage : Float32?
 
   def render
     div class: "flex items-center justify-between my-1 text-sm" do
       div class: "w-full h-8", style: "max-width: calc(100% - 4rem);" do
         div class: "bg-blue-200 rounded", style: "width: #{(percentage || 0.001)*100}%;height: 30px"
-        a href: domain || "#", class: "block px-2 text-black", style: "margin-top: -26px;", rel: "noreferrer" do
-          raw (domain || "").to_s
+        if !domain.nil? && domain.not_nil! == real_domain
+          raw "(direct)"
+        else
+          a href: domain || "#", class: "block px-2 text-black", style: "margin-top: -26px;", rel: "noreferrer" do
+            raw (domain || "").to_s
+          end
         end
       end
       span do

--- a/src/pages/domains/data/referrer.html.ecr
+++ b/src/pages/domains/data/referrer.html.ecr
@@ -7,11 +7,13 @@
   <div class="flex items-center justify-between my-1 h-10 text-sm subpixel-antialiased">
     <div class="w-full h-9" style="max-width: calc(100% - 4rem);">
       <div class="progress_bar" style="width: <%=(r.percentage || 0.001)*100%>%;height: 35px"></div>
-
+      <% if !r.referrer_domain.nil? && r.referrer_domain.not_nil! == @domain.address %>
+        (direct)
+      <% else %>
       <a class="block px-2 hover:underline" style="margin-top: -28px;", href="<%=(current_user.nil? ? Share::Referrer::Show.with(@domain.hashid, r.referrer_source.to_s, @period.to_s) : Domains::Referrer::Show.with(@domain.id, r.referrer_source.to_s, @period.to_s)).url%>">
-        <img src="https://api.faviconkit.com/<%=r.referrer_domain%>/16" class="inline align-middle mr-1 h-4 w-4 -mt-px" />
-        <%=r.referrer_source%>
+        <img src="https://api.faviconkit.com/<%=r.referrer_domain%>/16" class="inline align-middle mr-2 h-4 w-4 -mt-px" /><%=r.referrer_source%>
       </a>
+      <% end %>
     </div>
     <span>
       <%=r.count%>

--- a/src/pages/domains/paths/show_page.cr
+++ b/src/pages/domains/paths/show_page.cr
@@ -25,7 +25,7 @@ class Domains::Paths::ShowPage < Share::BasePage
           span "Percentage"
         end
         referrers.each do |event|
-          mount ReferrerEventComponent.new(domain: event.referrer_domain, percentage: event.percentage)
+          mount ReferrerEventComponent.new(domain: event.referrer_domain, real_domain: @domain.address, percentage: event.percentage)
         end
       end
     end

--- a/src/pages/domains/referrers/show_page.cr
+++ b/src/pages/domains/referrers/show_page.cr
@@ -14,7 +14,7 @@ class Domains::Referrer::ShowPage < Share::BasePage
       div class: "w-full p-5 bg-white rounded-md shadow-md my-3 mb-6" do
         para "Got #{total.to_s} Visitors from #{source} the last #{period_string}", class: "text-xl mb-2"
         events.each do |event|
-          mount ReferrerEventComponent.new(domain: event.referrer_domain, percentage: event.percentage)
+          mount ReferrerEventComponent.new(domain: event.referrer_domain, real_domain: @domain.address, percentage: event.percentage)
         end
       end
     end


### PR DESCRIPTION
This makes it more clear when the visitors come directly to the site, either by typing the address in or by a link by a site that has marked the link with `noreferrer`

Closing #25 